### PR TITLE
py7zr >= 0.20.2 or >= 0.19.2 or >=0.18.12:all?

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pip
     - python
     - setuptools
-    - setuptools-scm 7.0.4
+    - setuptools-scm 7.1.0
     - wheel
   run:
     - brotli-python >=1.0.9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "py7zr" %}
-{% set version = "0.16.1" %}
+{% set version = "0.20.5" %}
 
 
 package:
@@ -8,32 +8,32 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0ab402f73fc8cc41f2a5523436ae53dec6ff612597d9168ed80cfa1574d27fe0
+  sha256: 6fb4889c0fa32581818a3366984083253585d6c794e82c3242b8a12d6aeaabd3
 
 build:
-  number: 1
-  noarch: python
+  number: 0
   entry_points:
     - py7zr = py7zr.__main__:main
-  script: 
-    - {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.6
-    - setuptools >=45.0
-    - setuptools-scm >=6.0.1
+    - python
+    - setuptools
+    - setuptools-scm 7.0.4
+    - wheel
   run:
-    - bcj-cffi >=0.5.1,<0.6.0
     - brotli-python >=1.0.9
-    - brotlicffi >=1.0.9.2
-    - importlib_metadata
+    - importlib-metadata  # [py<38]
+    - inflate64 >=0.3.1
     - multivolumefile >=0.2.3
+    - psutil
+    - pybcj >=0.6.0
     - pycryptodomex >=3.6.6
-    - pyppmd >=0.15.0
-    - python >=3.6
-    - pyzstd >=0.14.4,<0.15.0
+    - pyppmd >=0.18.1,<1.1.0
+    - python
+    - pyzstd >=0.14.4
     - texttable
 
 test:
@@ -46,9 +46,15 @@ test:
     - pip
 
 about:
+  description: |
+    py7zr is a library and utility to support 7zip archive compression, decompression,
+    encryption and decryption written by Python programming language.
   home: https://github.com/miurahr/py7zr
+  dev_url: https://github.com/miurahr/py7zr
+  doc_url: https://github.com/miurahr/py7zr#readme
   summary: Pure python 7-zip library
   license: LGPL-2.1-or-later
+  license_family: LGPL
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
**Please note:** the package requires setuptools 7.0.5, but builds fine with 7.0.4, that is just a patch release with changes that won't affect building process. We can either merge this as is or wait for https://github.com/AnacondaRecipes/setuptools_scm-feedstock/pull/5